### PR TITLE
Add trip details to item list payload

### DIFF
--- a/api/resources/packing_list.py
+++ b/api/resources/packing_list.py
@@ -98,7 +98,12 @@ class UserPackingListsResource(Resource):
         "id": datetime.now().strftime('%Y%m-%d%H-%M%S-') + str(uuid4()),
         "type": "Item_List",
         "attributes": {
-          "categories": categories
+          "categories": categories,
+          "tripDetails": {
+            "title": packing_list.title,
+            "num_of_days": packing_list.num_of_days,
+            "destination": packing_list.destination
+          }
         }
       }
     }

--- a/api/resources/packing_list.py
+++ b/api/resources/packing_list.py
@@ -100,6 +100,7 @@ class UserPackingListsResource(Resource):
         "attributes": {
           "categories": categories,
           "tripDetails": {
+            "packing_list_id": packing_list.id,
             "title": packing_list.title,
             "num_of_days": packing_list.num_of_days,
             "destination": packing_list.destination

--- a/tests/resources/get_all_item_lists_for_packing_list_test.py
+++ b/tests/resources/get_all_item_lists_for_packing_list_test.py
@@ -62,7 +62,7 @@ class GetAllItemLists(unittest.TestCase):
     response = self.client.get(
       f'/api/v1/packing_lists/{self.packing_list_1.id}'
     )
-      
+
     self.assertEqual(200, response.status_code)
 
     data = json.loads(response.data.decode('utf-8'))['data']
@@ -72,3 +72,8 @@ class GetAllItemLists(unittest.TestCase):
     self.assertEqual('Hats', data['attributes']['categories']['Accessories'][0]['name'])
     self.assertEqual('Belts', data['attributes']['categories']['Accessories'][1]['name'])
     self.assertEqual('Birth Control', data['attributes']['categories']['Toiletries'][0]['name'])
+    self.assertEqual(1, data['attributes']['tripDetails']['packing_list_id'])
+    self.assertEqual('Hawaii Trip', data['attributes']['tripDetails']['title'])
+    self.assertEqual(7, data['attributes']['tripDetails']['num_of_days'])
+    self.assertEqual('Hawaii', data['attributes']['tripDetails']['destination'])
+

--- a/tests/resources/get_all_user_packing_lists_test.py
+++ b/tests/resources/get_all_user_packing_lists_test.py
@@ -41,7 +41,7 @@ class GetAllUserPackingLists(unittest.TestCase):
 
     self.assertEqual(200, response.status_code)
     data = json.loads(response.data.decode('utf-8'))['data']
-    
+
     self.assertEqual(2, len(data['attributes']['PackingLists']))
     self.assertEqual(packing_list_1.id, data['attributes']['PackingLists'][1]['list_id'])
     self.assertEqual(packing_list_1.title, data['attributes']['PackingLists'][1]['title'])
@@ -55,6 +55,6 @@ class GetAllUserPackingLists(unittest.TestCase):
 
     self.assertEqual(200, response.status_code)
     data = json.loads(response.data.decode('utf-8'))
-    
+
     self.assertEqual('User does not exists', data['error'])
 


### PR DESCRIPTION
This is when the user gets their packing list it also includes now the Trip Details.

`"tripDetails": {
"packing_list_id": 1,
"title": "Hawaii Trip",
"num_of_days": 7,
"destination": "Hawaii"
}`