### PR TITLE
Renaming GET payload variables for item_lists

### DIFF
--- a/api/resources/packing_list.py
+++ b/api/resources/packing_list.py
@@ -99,9 +99,9 @@ class UserPackingListsResource(Resource):
         "attributes": {
           "categories": categories,
           "tripDetails": {
-            "packing_list_id": packing_list.id,
+            "listId": packing_list.id,
             "title": packing_list.title,
-            "num_of_days": packing_list.num_of_days,
+            "duration": packing_list.num_of_days,
             "destination": packing_list.destination
           }
         }

--- a/tests/resources/get_all_item_lists_for_packing_list_test.py
+++ b/tests/resources/get_all_item_lists_for_packing_list_test.py
@@ -72,8 +72,8 @@ class GetAllItemLists(unittest.TestCase):
     self.assertEqual('Hats', data['attributes']['categories']['Accessories'][0]['name'])
     self.assertEqual('Belts', data['attributes']['categories']['Accessories'][1]['name'])
     self.assertEqual('Birth Control', data['attributes']['categories']['Toiletries'][0]['name'])
-    self.assertEqual(1, data['attributes']['tripDetails']['packing_list_id'])
+    self.assertEqual(1, data['attributes']['tripDetails']['listId'])
     self.assertEqual('Hawaii Trip', data['attributes']['tripDetails']['title'])
-    self.assertEqual(7, data['attributes']['tripDetails']['num_of_days'])
+    self.assertEqual(7, data['attributes']['tripDetails']['duration'])
     self.assertEqual('Hawaii', data['attributes']['tripDetails']['destination'])
 


### PR DESCRIPTION
## Description
- At the request of the frontend we changed the name of a few variables sent back in the payload of the GET endpoint for item_lists